### PR TITLE
Fix confusing API

### DIFF
--- a/lib/acts_as_time_trackable/tracker.rb
+++ b/lib/acts_as_time_trackable/tracker.rb
@@ -24,7 +24,7 @@ module ActsAsTimeTrackable
 
       def start_time_track(trackable)
         ActiveRecord::Base.transaction do
-          return if trackable == time_trackable
+          return current_entry if trackable == time_trackable
           stop_time_track
           time_entries.create!(time_trackable: trackable, started_at: Time.now)
         end

--- a/test/tracker_test.rb
+++ b/test/tracker_test.rb
@@ -40,6 +40,10 @@ class TrackerTest < ActiveSupport::TestCase
     @user.start_time_track(@task)
     @user.start_time_track(@task2)
     assert_equal [@task, @task2], @user.time_entries.map { |te| te.time_trackable }
+
+    entry1 = @user.start_time_track(@task)
+    entry2 = @user.start_time_track(@task)
+    assert_equal entry1, entry2
   end
 end
 


### PR DESCRIPTION
If tracker are already tracking the same task, `start_time_track` will return nil.
This is confusing, so I fixed it to always return the time entry.